### PR TITLE
Add safe wrapper for NV_ENC_INITIALIZE_PARAMS

### DIFF
--- a/examples/importing_vulkan_buffers.rs
+++ b/examples/importing_vulkan_buffers.rs
@@ -10,11 +10,11 @@ use nvidia_video_codec_sdk::{
         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
         NV_ENC_CODEC_H264_GUID,
         NV_ENC_H264_PROFILE_HIGH_GUID,
-        NV_ENC_INITIALIZE_PARAMS,
         NV_ENC_PRESET_P1_GUID,
         NV_ENC_TUNING_INFO,
     },
     Encoder,
+    EncoderInitParams,
 };
 use vulkano::{
     device::{
@@ -180,20 +180,20 @@ fn main() {
     let buffer_format = NV_ENC_BUFFER_FORMAT_ARGB;
     assert!(input_formats.contains(&buffer_format));
 
+    let tuning_info = NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY;
+
     // Get the preset config based on the selected encode guid (H.264), selected
     // preset (`LOW_LATENCY`), and tuning info (`ULTRA_LOW_LATENCY`).
     let mut preset_config = encoder
-        .get_preset_config(
-            encode_guid,
-            preset_guid,
-            NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY,
-        )
+        .get_preset_config(encode_guid, preset_guid, tuning_info)
         .expect("Encoder should be able to create config based on presets.");
 
     // Initialize a new encoder session based on the `preset_config`
     // we generated before.
-    let mut initialize_params = NV_ENC_INITIALIZE_PARAMS::new(encode_guid, WIDTH, HEIGHT);
+    let mut initialize_params = EncoderInitParams::new(encode_guid, WIDTH, HEIGHT);
     initialize_params
+        .preset_guid(preset_guid)
+        .tuning_info(tuning_info)
         .display_aspect_ratio(16, 9)
         .framerate(30, 1)
         .enable_picture_type_decision()

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -58,11 +58,10 @@ impl Session {
     /// #     sys::nvEncodeAPI::{
     /// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
     /// #         NV_ENC_CODEC_H264_GUID,
-    /// #         NV_ENC_INITIALIZE_PARAMS,
     /// #         NV_ENC_PIC_PARAMS,
     /// #         NV_ENC_PIC_STRUCT,
     /// #     },
-    /// #     Encoder,
+    /// #     Encoder, EncoderInitParams
     /// # };
     /// # const WIDTH: u32 = 1920;
     /// # const HEIGHT: u32 = 1080;
@@ -79,7 +78,7 @@ impl Session {
     /// # assert!(input_formats.contains(&buffer_format));
     ///
     /// //* Begin encoder session. *//
-    /// # let mut initialize_params = NV_ENC_INITIALIZE_PARAMS::new(encode_guid, WIDTH, HEIGHT);
+    /// # let mut initialize_params = EncoderInitParams::new(encode_guid, WIDTH, HEIGHT);
     /// # initialize_params.display_aspect_ratio(16, 9)
     /// #     .framerate(30, 1)
     /// #     .enable_picture_type_decision();
@@ -129,11 +128,10 @@ impl Session {
     /// #     sys::nvEncodeAPI::{
     /// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
     /// #         NV_ENC_CODEC_H264_GUID,
-    /// #         NV_ENC_INITIALIZE_PARAMS,
     /// #         NV_ENC_PIC_PARAMS,
     /// #         NV_ENC_PIC_STRUCT,
     /// #     },
-    /// #     Encoder,
+    /// #     Encoder, EncoderInitParams
     /// # };
     /// # const WIDTH: u32 = 1920;
     /// # const HEIGHT: u32 = 1080;
@@ -150,7 +148,7 @@ impl Session {
     /// # assert!(input_formats.contains(&buffer_format));
     ///
     /// //* Begin encoder session. *//
-    /// # let mut initialize_params = NV_ENC_INITIALIZE_PARAMS::new(encode_guid, WIDTH, HEIGHT);
+    /// # let mut initialize_params = EncoderInitParams::new(encode_guid, WIDTH, HEIGHT);
     /// # initialize_params.display_aspect_ratio(16, 9)
     /// #     .framerate(30, 1)
     /// #     .enable_picture_type_decision();
@@ -304,11 +302,10 @@ impl<'a> Buffer<'a> {
     /// #     sys::nvEncodeAPI::{
     /// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
     /// #         NV_ENC_CODEC_H264_GUID,
-    /// #         NV_ENC_INITIALIZE_PARAMS,
     /// #         NV_ENC_PIC_PARAMS,
     /// #         NV_ENC_PIC_STRUCT,
     /// #     },
-    /// #     Encoder,
+    /// #     Encoder, EncoderInitParams
     /// # };
     /// # const WIDTH: u32 = 1920;
     /// # const HEIGHT: u32 = 1080;
@@ -324,7 +321,7 @@ impl<'a> Buffer<'a> {
     /// # let input_formats = encoder.get_supported_input_formats(encode_guid).unwrap();
     /// # assert!(input_formats.contains(&buffer_format));
     /// //* Begin encoder session. *//
-    /// # let mut initialize_params = NV_ENC_INITIALIZE_PARAMS::new(encode_guid, WIDTH, HEIGHT);
+    /// # let mut initialize_params = EncoderInitParams::new(encode_guid, WIDTH, HEIGHT);
     /// # initialize_params.display_aspect_ratio(16, 9)
     /// #     .framerate(30, 1)
     /// #     .enable_picture_type_decision();

--- a/src/safe/mod.rs
+++ b/src/safe/mod.rs
@@ -20,6 +20,6 @@ pub use buffer::{
     EncoderOutput,
     RegisteredResource,
 };
-pub use encoder::Encoder;
+pub use encoder::{Encoder, EncoderInitParams};
 pub use result::{EncodeError, ErrorKind};
 pub use session::{CodecPictureParams, EncodePictureParams, Session};

--- a/src/safe/session.rs
+++ b/src/safe/session.rs
@@ -56,9 +56,8 @@ impl Session {
     /// #     sys::nvEncodeAPI::{
     /// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
     /// #         NV_ENC_CODEC_H264_GUID,
-    /// #         NV_ENC_INITIALIZE_PARAMS,
     /// #     },
-    /// #     Encoder,
+    /// #     Encoder, EncoderInitParams
     /// # };
     /// //* Create encoder. *//
     /// # let cuda_device = CudaDevice::new(0).unwrap();
@@ -72,7 +71,7 @@ impl Session {
     /// let session = encoder
     ///     .start_session(
     ///         NV_ENC_BUFFER_FORMAT_ARGB,
-    ///         NV_ENC_INITIALIZE_PARAMS::new(encode_guid, 1920, 1080),
+    ///         EncoderInitParams::new(encode_guid, 1920, 1080),
     ///     )
     ///     .unwrap();
     /// // We can still use the encoder like this:
@@ -117,11 +116,10 @@ impl Session {
     /// #     sys::nvEncodeAPI::{
     /// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
     /// #         NV_ENC_CODEC_H264_GUID,
-    /// #         NV_ENC_INITIALIZE_PARAMS,
     /// #         NV_ENC_PIC_PARAMS,
     /// #         NV_ENC_PIC_STRUCT,
     /// #     },
-    /// #     Encoder,
+    /// #     Encoder, EncoderInitParams,
     /// #     EncodePictureParams
     /// # };
     /// # const WIDTH: u32 = 1920;
@@ -140,7 +138,7 @@ impl Session {
     /// # assert!(input_formats.contains(&buffer_format));
     ///
     /// // Begin encoder session.
-    /// let mut initialize_params = NV_ENC_INITIALIZE_PARAMS::new(encode_guid, WIDTH, HEIGHT);
+    /// let mut initialize_params = EncoderInitParams::new(encode_guid, WIDTH, HEIGHT);
     /// initialize_params.display_aspect_ratio(16, 9)
     ///     .framerate(30, 1)
     ///     .enable_picture_type_decision();

--- a/tests/blanks.rs
+++ b/tests/blanks.rs
@@ -10,14 +10,10 @@ use std::{
 
 use cudarc::driver::CudaDevice;
 use nvidia_video_codec_sdk::{
-    sys::nvEncodeAPI::{
-        GUID,
-        NV_ENC_BUFFER_FORMAT,
-        NV_ENC_CODEC_H264_GUID,
-        NV_ENC_INITIALIZE_PARAMS,
-    },
+    sys::nvEncodeAPI::{GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID},
     EncodeError,
     Encoder,
+    EncoderInitParams,
     ErrorKind,
 };
 
@@ -46,7 +42,7 @@ fn encode_blanks<P: AsRef<Path>>(
 
     // Initialize encoder.
     let encoder = Encoder::initialize_with_cuda(cuda_device)?;
-    let mut initialize_params = NV_ENC_INITIALIZE_PARAMS::new(ENCODE_GUID, WIDTH, HEIGHT);
+    let mut initialize_params = EncoderInitParams::new(ENCODE_GUID, WIDTH, HEIGHT);
     initialize_params
         .enable_picture_type_decision()
         .framerate(FRAMERATE, 1);


### PR DESCRIPTION
Fix this [issue](https://github.com/ViliamVadocz/nvidia-video-codec-sdk/issues/18).