### PR TITLE
Library stubs for containerized builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 /Cargo.lock
 .vscode/
+/stubs
 *.bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvidia-video-codec-sdk"
-version = "0.3.1"
+version = "0.3.4"
 edition = "2021"
 license = "MIT"
 rust-version = "1.70"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Versions:
 
 ## Installation
 
-The build script will try to automatically locate your NVIDIA Video Codec SDK installation.
-You can help it by setting the environment variable `NVIDIA_VIDEO_CODEC_SDK_PATH` to the directory containing the library files. 
+Nvidia library stubs are used, dynamic linking at runtime.
+You should have these available for your dynamic loader to load:
+
 - `nvEncodeAPI.lib` and `nvcuvid.lib` on Windows,
 - `libnvidia-encode.so` and `libnvcuvid.so` on Linux.

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -559,13 +559,13 @@ impl EncoderOutput for Bitstream<'_> {
 /// it automatically unlocks the buffer then the lock goes out of scope.
 #[derive(Debug)]
 pub struct BitstreamLock<'a, 'b> {
-    bitstream: &'a Bitstream<'b>,
-    data: &'a [u8],
+    pub bitstream: &'a Bitstream<'b>,
+    pub data: &'a [u8],
     // statistics and other info
-    frame_index: u32,
-    timestamp: u64,
-    duration: u64,
-    picture_type: NV_ENC_PIC_TYPE,
+    pub frame_index: u32,
+    pub timestamp: u64,
+    pub duration: u64,
+    pub picture_type: NV_ENC_PIC_TYPE,
     // TODO: other fields
 }
 

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -281,6 +281,24 @@ pub struct Buffer<'a> {
 unsafe impl Send for Buffer<'_> {}
 
 impl<'a> Buffer<'a> {
+    pub fn get_ptr(&self) ->  *mut c_void {
+        self.ptr
+    }
+
+    pub fn pitch(&self) -> u32 {
+        self.pitch
+    }
+
+    pub fn create(
+        ptr: *mut c_void,
+        pitch: u32,
+        encoder: &'a Encoder,
+    ) -> Self {
+        Self {
+            ptr, pitch, encoder
+        }
+    }
+
     /// Lock the input buffer.
     ///
     /// On a successful lock you get a [`BufferLock`] which can be used to write
@@ -459,21 +477,7 @@ pub struct Bitstream<'a> {
 
 unsafe impl Send for Bitstream<'_> {}
 
-impl<'a> Bitstream<'a> {
-    pub fn create(
-        ptr: *mut c_void,
-        encoder: &'a Encoder,
-    ) -> Self {
-        Self {
-            ptr, encoder
-        }
-    }
-}
-
 impl Bitstream<'_> {
-    pub fn get_ptr(&self) ->  *mut c_void {
-        self.ptr
-    }
     /// Lock the output bitstream.
     ///
     /// On a successful lock you get a [`BitstreamLock`] which can be used to

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -277,9 +277,28 @@ pub struct Buffer<'a> {
     encoder: &'a Encoder,
 }
 
+
 unsafe impl Send for Buffer<'_> {}
 
 impl<'a> Buffer<'a> {
+    pub fn get_ptr(&self) ->  *mut c_void {
+        self.ptr
+    }
+
+    pub fn pitch(&self) -> u32 {
+        self.pitch
+    }
+
+    pub fn create(
+        ptr: *mut c_void,
+        pitch: u32,
+        encoder: &'a Encoder,
+    ) -> Self {
+        Self {
+            ptr, pitch, encoder
+        }
+    }
+
     /// Lock the input buffer.
     ///
     /// On a successful lock you get a [`BufferLock`] which can be used to write

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -559,13 +559,13 @@ impl EncoderOutput for Bitstream<'_> {
 /// it automatically unlocks the buffer then the lock goes out of scope.
 #[derive(Debug)]
 pub struct BitstreamLock<'a, 'b> {
-    pub bitstream: &'a Bitstream<'b>,
-    pub data: &'a [u8],
+    bitstream: &'a Bitstream<'b>,
+    data: &'a [u8],
     // statistics and other info
-    pub frame_index: u32,
-    pub timestamp: u64,
-    pub duration: u64,
-    pub picture_type: NV_ENC_PIC_TYPE,
+    frame_index: u32,
+    timestamp: u64,
+    duration: u64,
+    picture_type: NV_ENC_PIC_TYPE,
     // TODO: other fields
 }
 

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -281,24 +281,6 @@ pub struct Buffer<'a> {
 unsafe impl Send for Buffer<'_> {}
 
 impl<'a> Buffer<'a> {
-    pub fn get_ptr(&self) ->  *mut c_void {
-        self.ptr
-    }
-
-    pub fn pitch(&self) -> u32 {
-        self.pitch
-    }
-
-    pub fn create(
-        ptr: *mut c_void,
-        pitch: u32,
-        encoder: &'a Encoder,
-    ) -> Self {
-        Self {
-            ptr, pitch, encoder
-        }
-    }
-
     /// Lock the input buffer.
     ///
     /// On a successful lock you get a [`BufferLock`] which can be used to write
@@ -477,7 +459,21 @@ pub struct Bitstream<'a> {
 
 unsafe impl Send for Bitstream<'_> {}
 
+impl<'a> Bitstream<'a> {
+    pub fn create(
+        ptr: *mut c_void,
+        encoder: &'a Encoder,
+    ) -> Self {
+        Self {
+            ptr, encoder
+        }
+    }
+}
+
 impl Bitstream<'_> {
+    pub fn get_ptr(&self) ->  *mut c_void {
+        self.ptr
+    }
     /// Lock the output bitstream.
     ///
     /// On a successful lock you get a [`BitstreamLock`] which can be used to

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -453,7 +453,7 @@ impl Drop for BufferLock<'_, '_> {
 /// The buffer is automatically destroyed when dropped.
 #[derive(Debug)]
 pub struct Bitstream<'a> {
-    pub(crate) ptr: *mut c_void,
+    pub ptr: *mut c_void,
     encoder: &'a Encoder,
 }
 

--- a/src/safe/buffer.rs
+++ b/src/safe/buffer.rs
@@ -453,7 +453,7 @@ impl Drop for BufferLock<'_, '_> {
 /// The buffer is automatically destroyed when dropped.
 #[derive(Debug)]
 pub struct Bitstream<'a> {
-    pub ptr: *mut c_void,
+    pub(crate) ptr: *mut c_void,
     encoder: &'a Encoder,
 }
 

--- a/src/safe/encoder.rs
+++ b/src/safe/encoder.rs
@@ -47,9 +47,9 @@ use crate::sys::nvEncodeAPI::{
 /// See [NVIDIA Video Codec SDK - Video Encoder API Programming Guide](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.0/nvenc-video-encoder-api-prog-guide/index.html).
 #[derive(Debug)]
 pub struct Encoder {
-    pub(crate) ptr: *mut c_void,
+    pub ptr: *mut c_void,
     // Used to fetch the device pointer for an externally allocated buffer
-    pub(crate) ctx: Arc<CudaContext>,
+    pub ctx: Arc<CudaContext>,
 }
 
 /// The client must flush the encoder before freeing any resources.

--- a/src/safe/encoder.rs
+++ b/src/safe/encoder.rs
@@ -47,9 +47,9 @@ use crate::sys::nvEncodeAPI::{
 /// See [NVIDIA Video Codec SDK - Video Encoder API Programming Guide](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.0/nvenc-video-encoder-api-prog-guide/index.html).
 #[derive(Debug)]
 pub struct Encoder {
-    pub ptr: *mut c_void,
+    pub(crate) ptr: *mut c_void,
     // Used to fetch the device pointer for an externally allocated buffer
-    pub ctx: Arc<CudaContext>,
+    pub(crate) ctx: Arc<CudaContext>,
 }
 
 /// The client must flush the encoder before freeing any resources.

--- a/src/sys/stubs/nvEncodeAPI.c
+++ b/src/sys/stubs/nvEncodeAPI.c
@@ -1,0 +1,45 @@
+#include "nvEncodeAPI.h"
+
+NVENCSTATUS NVENCAPI NvEncOpenEncodeSession                     (void* device, uint32_t deviceType, void** encoder) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodeGUIDCount                    (void* encoder, uint32_t* encodeGUIDCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodeGUIDs                        (void* encoder, GUID* GUIDs, uint32_t guidArraySize, uint32_t* GUIDCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodeProfileGUIDCount                    (void* encoder, GUID encodeGUID, uint32_t* encodeProfileGUIDCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodeProfileGUIDs                               (void* encoder, GUID encodeGUID, GUID* profileGUIDs, uint32_t guidArraySize, uint32_t* GUIDCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetInputFormatCount                   (void* encoder, GUID encodeGUID, uint32_t* inputFmtCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetInputFormats                       (void* encoder, GUID encodeGUID, NV_ENC_BUFFER_FORMAT* inputFmts, uint32_t inputFmtArraySize, uint32_t* inputFmtCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodeCaps                     (void* encoder, GUID encodeGUID, NV_ENC_CAPS_PARAM* capsParam, int* capsVal) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodePresetCount              (void* encoder, GUID encodeGUID, uint32_t* encodePresetGUIDCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodePresetGUIDs                  (void* encoder, GUID encodeGUID, GUID* presetGUIDs, uint32_t guidArraySize, uint32_t* encodePresetGUIDCount) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfig               (void* encoder, GUID encodeGUID, GUID  presetGUID, NV_ENC_PRESET_CONFIG* presetConfig) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfigEx               (void* encoder, GUID encodeGUID, GUID  presetGUID, NV_ENC_TUNING_INFO tuningInfo, NV_ENC_PRESET_CONFIG* presetConfig) { return 0; }
+NVENCSTATUS NVENCAPI NvEncInitializeEncoder                     (void* encoder, NV_ENC_INITIALIZE_PARAMS* createEncodeParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncCreateInputBuffer                     (void* encoder, NV_ENC_CREATE_INPUT_BUFFER* createInputBufferParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncDestroyInputBuffer                    (void* encoder, NV_ENC_INPUT_PTR inputBuffer) { return 0; }
+NVENCSTATUS NVENCAPI NvEncSetIOCudaStreams                     (void* encoder, NV_ENC_CUSTREAM_PTR inputStream, NV_ENC_CUSTREAM_PTR outputStream) { return 0; }
+NVENCSTATUS NVENCAPI NvEncCreateBitstreamBuffer                 (void* encoder, NV_ENC_CREATE_BITSTREAM_BUFFER* createBitstreamBufferParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, NV_ENC_OUTPUT_PTR bitstreamBuffer) { return 0; }
+NVENCSTATUS NVENCAPI NvEncEncodePicture                         (void* encoder, NV_ENC_PIC_PARAMS* encodePicParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncLockBitstream                         (void* encoder, NV_ENC_LOCK_BITSTREAM* lockBitstreamBufferParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncUnlockBitstream                       (void* encoder, NV_ENC_OUTPUT_PTR bitstreamBuffer) { return 0; }
+NVENCSTATUS NVENCAPI NvEncRestoreEncoderState                    (void* encoder, NV_ENC_RESTORE_ENCODER_STATE_PARAMS* restoreState) { return 0; }
+NVENCSTATUS NVENCAPI NvEncLockInputBuffer                      (void* encoder, NV_ENC_LOCK_INPUT_BUFFER* lockInputBufferParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncUnlockInputBuffer                     (void* encoder, NV_ENC_INPUT_PTR inputBuffer) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetEncodeStats                        (void* encoder, NV_ENC_STAT* encodeStats) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetSequenceParams                     (void* encoder, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload) { return 0; }
+NVENCSTATUS NVENCAPI NvEncGetSequenceParamEx                     (void* encoder, NV_ENC_INITIALIZE_PARAMS* encInitParams, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload) { return 0; }
+NVENCSTATUS NVENCAPI NvEncRegisterAsyncEvent                    (void* encoder, NV_ENC_EVENT_PARAMS* eventParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncUnregisterAsyncEvent                  (void* encoder, NV_ENC_EVENT_PARAMS* eventParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncMapInputResource                         (void* encoder, NV_ENC_MAP_INPUT_RESOURCE* mapInputResParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncUnmapInputResource                         (void* encoder, NV_ENC_INPUT_PTR mappedInputBuffer) { return 0; }
+NVENCSTATUS NVENCAPI NvEncDestroyEncoder                        (void* encoder) { return 0; }
+NVENCSTATUS NVENCAPI NvEncInvalidateRefFrames(void* encoder, uint64_t invalidRefFrameTimeStamp) { return 0; }
+NVENCSTATUS NVENCAPI NvEncOpenEncodeSessionEx                   (NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS *openSessionExParams, void** encoder) { return 0; }
+NVENCSTATUS NVENCAPI NvEncRegisterResource                      (void* encoder, NV_ENC_REGISTER_RESOURCE* registerResParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncUnregisterResource                    (void* encoder, NV_ENC_REGISTERED_PTR registeredResource) { return 0; }
+NVENCSTATUS NVENCAPI NvEncReconfigureEncoder                   (void *encoder, NV_ENC_RECONFIGURE_PARAMS* reInitEncodeParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncCreateMVBuffer                        (void* encoder, NV_ENC_CREATE_MV_BUFFER* createMVBufferParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncDestroyMVBuffer                       (void* encoder, NV_ENC_OUTPUT_PTR mvBuffer) { return 0; }
+NVENCSTATUS NVENCAPI NvEncRunMotionEstimationOnly               (void* encoder, NV_ENC_MEONLY_PARAMS* meOnlyParams) { return 0; }
+NVENCSTATUS NVENCAPI NvEncodeAPIGetMaxSupportedVersion          (uint32_t* version) { return 0; }
+NVENCSTATUS NVENCAPI NvEncLookaheadPicture          (void* encoder, NV_ENC_LOOKAHEAD_PIC_PARAMS *lookaheadParamas) { return 0; }
+NVENCSTATUS NVENCAPI NvEncodeAPICreateInstance(NV_ENCODE_API_FUNCTION_LIST *functionList) { return 0; }

--- a/src/sys/stubs/nvcuvid.c
+++ b/src/sys/stubs/nvcuvid.c
@@ -1,0 +1,10 @@
+#include <nvcuvid.h>
+CUresult CUDAAPI cuvidCreateVideoSource(CUvideosource *pObj, const char *pszFileName, CUVIDSOURCEPARAMS *pParams) { return 0; }
+CUresult CUDAAPI cuvidCreateVideoSourceW(CUvideosource *pObj, const wchar_t *pwszFileName, CUVIDSOURCEPARAMS *pParams) { return 0; }
+CUresult CUDAAPI cuvidDestroyVideoSource(CUvideosource obj) { return 0; }
+CUresult CUDAAPI cuvidSetVideoSourceState(CUvideosource obj, cudaVideoState state) { return 0; }
+CUresult CUDAAPI cuvidGetSourceVideoFormat(CUvideosource obj, CUVIDEOFORMAT *pvidfmt, unsigned int flags) { return 0; }
+CUresult CUDAAPI cuvidGetSourceAudioFormat(CUvideosource obj, CUAUDIOFORMAT *paudfmt, unsigned int flags) { return 0; }
+CUresult CUDAAPI cuvidCreateVideoParser(CUvideoparser *pObj, CUVIDPARSERPARAMS *pParams) { return 0; }
+CUresult CUDAAPI cuvidParseVideoData(CUvideoparser obj, CUVIDSOURCEDATAPACKET *pPacket) { return 0; }
+CUresult CUDAAPI cuvidDestroyVideoParser(CUvideoparser obj) { return 0; }


### PR DESCRIPTION
I've added library stubs for docker builds. Making this crate fully docker compatible.

It falls back for dummy .so files on build time and uses actual nvidia libs during runtime and dynamic loading.

I could not use cc for shared libraries since it apparently is a compilation tool and not a linking one.

So I've used Command and gcc / cl.exe, however I did not test it on a windows machine because I do not have one. 